### PR TITLE
Add get_company_documents: list corpus docs by company ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ These are the main functions powered by the PlatformAPI Module:
 2. Document Upload and Processing
 3. Corpus Smart Search
 4. Topic Research
+5. Company Document Retrieval
 
 &nbsp;
 ### Document Management and Analytics
@@ -271,6 +272,66 @@ The supported corpuses are: ['transcripts', 'sec', 'nonsec']:
 resFilters = pronto.get_smart_search_filters(corpus='transcripts')
 ```
 
+### Company Document Retrieval
+
+The SDK allows users to retrieve a list of documents filed by specific companies directly from the ProntoNLP corpus — without needing a search query or topic filter.
+This is useful for building document inventories, running coverage checks, or retrieving all filings of a given type for a set of companies.
+
+Users can retrieve documents using the `get_company_documents` function.
+
+Input parameters include:
+- `companies`: list of companyIds to retrieve documents for (required, use `getCompanyId` to resolve names/tickers)
+- `corpus`: `'transcripts'`, `'sec'`, or `'nonsec'` (optional — omit to search across all corpora)
+- `doc_type`: a document type label to filter by, e.g. `'Earnings Calls'`, `'10-Q'`, `'10-K'`, `'QR'` (optional)
+- `start_date`: start date (YYYY-MM-DD) for document search (default=current_date - 90 days)
+- `end_date`: end date (YYYY-MM-DD) for document search (default=current_date)
+- `country`: filter by company HQ country (optional)
+- `nResults`: maximum number of documents to return, paginates automatically (default=100)
+
+```python
+# Step 1: resolve company name or ticker to a companyId
+nvda = pronto.getCompanyId('NVIDIA')
+nvda_id = nvda[0]['id']  # '32307'
+
+# Step 2: retrieve all 10-Q and 10-K filings for the last 2 years
+tenq_docs = pronto.get_company_documents(
+    companies=[nvda_id],
+    corpus='sec',
+    doc_type='10-Q',
+    start_date='2023-01-01',
+    end_date='2025-12-31',
+    nResults=50,
+)
+
+tenk_docs = pronto.get_company_documents(
+    companies=[nvda_id],
+    corpus='sec',
+    doc_type='10-K',
+    start_date='2023-01-01',
+    end_date='2025-12-31',
+)
+
+# Retrieve earnings call transcripts for multiple companies
+apple_id = pronto.getCompanyId('Apple')[0]['id']
+msft_id  = pronto.getCompanyId('Microsoft')[0]['id']
+
+transcripts = pronto.get_company_documents(
+    companies=[apple_id, msft_id],
+    corpus='transcripts',
+    doc_type='Earnings Calls',
+    start_date='2024-01-01',
+)
+```
+
+Each result is a document metadata record containing fields such as `transcriptId`, `title`, `date`, `documentType`, `companyName`, `corpus`, and more.
+
+To view the available document types per corpus, use the `get_smart_search_filters` helper:
+```python
+filters = pronto.get_smart_search_filters(corpus='sec')
+# SEC doc types: ['8-K', '6-K', '10-Q', '10-K', '20-F', '40-F']
+```
+
+&nbsp;
 ### Add Context to Query Results Helper
 Users may require a broader context for the query results. For example, 3 sentences before and after the event or matched result. To retreive result context, use the 'get_context' helper function. 
 

--- a/pronto_nlp/PlatformAPI.py
+++ b/pronto_nlp/PlatformAPI.py
@@ -373,6 +373,81 @@ class ProntoPlatformAPI:
             response =  'no company found'
             return response
 
+    def get_company_documents(self, companies, corpus=None, doc_type=None, start_date=None, end_date=None, country=None, nResults=100) -> List:
+        """Retrieve a list of documents for given company IDs.
+
+        Parameters
+        ----------
+        companies : list[str]
+            List of companyIds (use getCompanyId to resolve names/tickers).
+        corpus : str, optional
+            One of 'transcripts', 'sec', 'nonsec'. Defaults to all corpora.
+        doc_type : str, optional
+            Document type label, e.g. 'Earnings Calls', '10-Q', 'QR'.
+        start_date : str, optional
+            Start date in 'YYYY-MM-DD' format. Defaults to 90 days ago.
+        end_date : str, optional
+            End date in 'YYYY-MM-DD' format. Defaults to today.
+        country : str, optional
+            Filter by HQ country.
+        nResults : int, optional
+            Max number of documents to return (default 100, max 10000).
+
+        Returns
+        -------
+        list[dict]
+            List of document metadata records.
+        """
+        if not companies:
+            raise ValueError("'companies' must be a non-empty list of companyIds")
+
+        if start_date is None:
+            start_date = (datetime.today() - timedelta(days=90)).strftime("%Y-%m-%d")
+        elif not _is_valid_date_format(start_date):
+            raise ValueError(f"start_date must be 'YYYY-MM-DD', got: '{start_date}'")
+
+        if end_date is None:
+            end_date = datetime.today().strftime("%Y-%m-%d")
+        elif not _is_valid_date_format(end_date):
+            raise ValueError(f"end_date must be 'YYYY-MM-DD', got: '{end_date}'")
+
+        page_size = min(nResults, 100)
+        request_obj = {
+            "retrieveType": "document",
+            "companiesIds": companies,
+            "dateRange": {"gte": start_date, "lte": end_date},
+            "size": page_size,
+            "from": 0,
+        }
+
+        if corpus:
+            if corpus not in self._platform_corpus_map:
+                raise ValueError(f"corpus must be one of {list(self._platform_corpus_map.keys())}")
+            request_obj["corpus"] = self._platform_corpus_map[corpus]
+
+        if doc_type:
+            request_obj["documentTypes"] = [doc_type]
+
+        if country:
+            request_obj["hqCountries"] = [country]
+
+        all_results = []
+        while len(all_results) < nResults:
+            request_obj["from"] = len(all_results)
+            request_obj["size"] = min(page_size, nResults - len(all_results))
+            requestResult, url = PerformRequest(self._base_headers, self._URL_Get_Meta_Data,
+                                                request_obj=request_obj, method='POST')
+            batch = requestResult['data']['results']
+            total = requestResult['data'].get('total', len(batch))
+            all_results.extend(batch)
+            if len(batch) == 0 or len(all_results) >= total:
+                break
+
+        self._user_stats.track(event_name='SDK Get Company Documents',
+                               properties={'endpoint': url, 'corpus': corpus, 'companiesCount': len(companies), 'resultsCount': len(all_results)})
+        print(f"Found {len(all_results)} documents")
+        return all_results
+
     def delete_fief_model(self, modelName):
         if self._authToken is None:
             self._refresh_authToken()


### PR DESCRIPTION
## Summary

- Adds a new `get_company_documents()` method to `ProntoPlatformAPI` that retrieves a flat list of documents for given company IDs from the ProntoNLP corpus (transcripts, SEC, or non-SEC filings)
- No search query or topic filter required — useful for building document inventories or fetching all filings of a specific type for a company
- Supports filtering by `corpus`, `doc_type`, `start_date`, `end_date`, and `country`, with automatic pagination up to `nResults`
- Documents the new method in `README.md` with full parameter descriptions and usage examples

## What changed

**`pronto_nlp/PlatformAPI.py`**
New method `get_company_documents()` added after `getCompanyId`. Calls the existing `get-metadata-results` endpoint with `retrieveType: "document"` and `companiesIds`, paginating automatically until `nResults` is reached or the corpus is exhausted.

**`README.md`**
New *Company Document Retrieval* section added between Topic Research and the context helper, with step-by-step examples for 10-Q/10-K retrieval and multi-company transcript fetches.

## Usage

```python
# Resolve company name to ID
nvda_id = pronto.getCompanyId('NVIDIA')[0]['id']

# List all 10-K filings for the last 2 years
docs = pronto.get_company_documents(
    companies=[nvda_id],
    corpus='sec',
    doc_type='10-K',
    start_date='2023-01-01',
    end_date='2025-12-31',
)
```

## Test plan

- [x] Verified login and `getCompanyId` still work unchanged
- [x] Fetched NVIDIA 10-Q (6 results) and 10-K (2 results) for 2023–2025 — counts match expected SEC filing cadence
- [x] Fetched transcripts for Apple + Microsoft across multiple companies in one call
- [x] Pagination logic confirmed: `from` offset advances correctly across pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)