### PR TITLE
Add get_company_documents, doc_ids filter for smart search & topic research

### DIFF
--- a/pronto_nlp/PlatformAPI.py
+++ b/pronto_nlp/PlatformAPI.py
@@ -839,7 +839,7 @@ class ProntoPlatformAPI:
         # request_obj['size'] = size
         return requestResultList
 
-    def _check_request(self, corpus, companies=None, sector=None, watchlist=None, doc_type=None, start_date=None, end_date=None):
+    def _check_request(self, corpus, companies=None, sector=None, watchlist=None, doc_type=None, start_date=None, end_date=None, doc_ids=None):
         if not corpus:
             raise ValueError("'corpus' must be specified")
 
@@ -856,11 +856,13 @@ class ProntoPlatformAPI:
             'S&P Transcripts' : {'label': 'Earnings Calls'}
         }
 
-        if sector is None and watchlist is None and companies is None:
+        if sector is None and watchlist is None and companies is None and not doc_ids:
             raise ValueError(
                 f"Sector or Watchlist must be specified\n Sectors -> {available_sectors}\n Watchlists -> {available_watchlists}")
 
-        if companies is not None:
+        if doc_ids is not None:
+            search_type = 'document'
+        elif companies is not None:
             search_type = 'company'
         elif sector is not None:
             if sector not in available_sectors:
@@ -971,10 +973,10 @@ class ProntoPlatformAPI:
 
         return results
 
-    def run_smart_search(self, corpus, searchQ, sector=None, watchlist=None, sentiment=None, companies=None, country=None, doc_type=None, start_date=None, end_date=None, similarity_threshold=.50) -> Dict:
+    def run_smart_search(self, corpus, searchQ, sector=None, watchlist=None, sentiment=None, companies=None, country=None, doc_type=None, start_date=None, end_date=None, similarity_threshold=.50, doc_ids=None) -> Dict:
         if not searchQ:
             raise ValueError("'searchQ' must be specified")
-        search_type, doc_type, start_date, end_date, resFilters = self._check_request(corpus, companies, sector, watchlist, doc_type, start_date, end_date)
+        search_type, doc_type, start_date, end_date, resFilters = self._check_request(corpus, companies, sector, watchlist, doc_type, start_date, end_date, doc_ids=doc_ids)
 
         request_obj = {
             'dateRange': {'gte': start_date, 'lte': end_date},
@@ -1019,6 +1021,15 @@ class ProntoPlatformAPI:
             task = ('companies', request_obj, similarity_threshold)
             results = [self._process_subQ(task)]
             # request_obj['retrieveType'] = 'company'
+
+        elif search_type == 'document':
+            print('Running Document ID based Query')
+            results = []
+            for doc_id in tqdm(doc_ids, total=len(doc_ids)):
+                req_obj = copy.deepcopy(request_obj)
+                req_obj['docId'] = doc_id
+                results.append((doc_id, req_obj, similarity_threshold))
+            results = [self._process_subQ(task) for task in results]
 
         else:
             raise NotImplementedError

--- a/pronto_nlp/PlatformAPI.py
+++ b/pronto_nlp/PlatformAPI.py
@@ -1024,12 +1024,9 @@ class ProntoPlatformAPI:
 
         elif search_type == 'document':
             print('Running Document ID based Query')
-            results = []
-            for doc_id in tqdm(doc_ids, total=len(doc_ids)):
-                req_obj = copy.deepcopy(request_obj)
-                req_obj['docId'] = doc_id
-                results.append((doc_id, req_obj, similarity_threshold))
-            results = [self._process_subQ(task) for task in results]
+            request_obj['docIds'] = doc_ids
+            task = ('documents', request_obj, similarity_threshold)
+            results = [self._process_subQ(task)]
 
         else:
             raise NotImplementedError

--- a/pronto_nlp/PlatformAPI.py
+++ b/pronto_nlp/PlatformAPI.py
@@ -913,8 +913,8 @@ class ProntoPlatformAPI:
         allEventTypes.sort()
         return allEventTypes
 
-    def run_topic_research(self, corpus, nResults=1_000, companies=None, country=None, sentiment=None, eventType=None, freeText=None, sector=None, watchlist=None, doc_type=None, start_date=None, end_date=None) -> List:
-        search_type, doc_type, start_date, end_date, resFilters = self._check_request(corpus, companies, sector, watchlist, doc_type, start_date, end_date)
+    def run_topic_research(self, corpus, nResults=1_000, companies=None, country=None, sentiment=None, eventType=None, freeText=None, sector=None, watchlist=None, doc_type=None, start_date=None, end_date=None, doc_ids=None) -> List:
+        search_type, doc_type, start_date, end_date, resFilters = self._check_request(corpus, companies, sector, watchlist, doc_type, start_date, end_date, doc_ids=doc_ids)
         size = 1_000
         platform_corpus_name = self._platform_corpus_map[corpus]
         doc_type = doc_type['label']
@@ -952,7 +952,9 @@ class ProntoPlatformAPI:
             else:
                 raise ValueError(f"eventType must be one of these options -> {avail_topics}")
 
-        if search_type == 'company':
+        if search_type == 'document':
+            request_obj['transcriptsIds'] = doc_ids
+        elif search_type == 'company':
             request_obj['companiesIds'] = companies
             request_obj['retrieveType'] = 'company'
         elif search_type == 'sector':

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='pronto_nlp',
-    version='0.5.4',
+    version='0.5.5',
     packages=find_packages(),
     install_requires=[
         'boto3',


### PR DESCRIPTION
## Summary

- Add \`get_company_documents()\` — retrieve a list of corpus documents for given company IDs without needing a search query
- Add \`doc_ids\` parameter to \`run_smart_search()\` — scope vector search to specific document IDs in a single request (requires server-side \`docIds\` array support to be deployed)
- Add \`doc_ids\` parameter to \`run_topic_research()\` — scope event/topic research to specific document IDs using native \`transcriptsIds\` support, no server changes needed
- Bump version to 0.5.5
- README updated with Company Document Retrieval section and examples

## What changed

**\`pronto_nlp/PlatformAPI.py\`**
- New \`get_company_documents()\` method calling \`get-metadata-results\` with \`retrieveType: "document"\`
- \`_check_request()\` accepts \`doc_ids\` as an alternative to companies/sector/watchlist, returning \`search_type='document'\`
- \`run_smart_search()\` — new \`doc_ids\` param, sends \`docIds\` array in a single request, results keyed as \`'documents'\`
- \`run_topic_research()\` — new \`doc_ids\` param, passes \`transcriptsIds\` to the research endpoint

**\`setup.py\`** — version \`0.5.4\` → \`0.5.5\`

**\`README.md\`** — new Company Document Retrieval section

## Notes
- \`run_smart_search\` with \`doc_ids\` requires the server-side change to \`get-vector-search-results\` (accepting \`docIds[]\` array) to be deployed
- \`run_topic_research\` with \`doc_ids\` works immediately — \`transcriptsIds\` is already natively supported

## Test plan
- [x] \`get_company_documents\` — fetched NVIDIA 10-Q (6) and 10-K (2) for 2023–2025
- [x] \`run_topic_research\` with \`doc_ids\` — validated both docs return correct totals (788 + 841 = 1629), no result leakage, eventType/freeText filters work alongside doc_ids, bogus ID returns 0
- [x] Version bump is non-breaking (additive only)